### PR TITLE
Fix/vputz fix contractviolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.hypothesis/
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,6 @@ build-backend = "poetry.core.masonry.api"
 [[tool.mypy.overrides]]
 module = [
   "pytz",
+  "intervaltree",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fenestrate"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Vic Putz <vbputz@gmail.com>"]
 

--- a/tests/test_time_windows.py
+++ b/tests/test_time_windows.py
@@ -3,6 +3,9 @@ import datetime
 import arrow
 import pytest
 import pytz
+from hypothesis import assume, given
+from hypothesis.strategies import (composite, datetimes, sampled_from, sets,
+                                   times)
 
 from fenestrate import selectors
 from fenestrate.fenestrate import (ConcreteWindow, DailyWindow,
@@ -71,17 +74,20 @@ weekly = DailyWindow(
     [
         (
             arrow.get("2020-06-24 12:25:00").replace(tzinfo="US/Eastern"),
-            # this one hits the exclusion window so the availability window is reduced
+            # this one hits the exclusion window so the availability window is reduced to
+            # start at the end of the exclusion window
             ConcreteWindow(
-                from_time=arrow.get("2020-06-24 12:25:00").replace(tzinfo="US/Eastern"),
+                from_time=arrow.get("2020-06-24 12:30:00").replace(tzinfo="US/Eastern"),
                 to_time=arrow.get("2020-06-24 13:00:00").replace(tzinfo="US/Eastern"),
             ),
         ),
         (
             arrow.get("2020-06-24 11:01:00").replace(tzinfo="US/Eastern"),
+            # this is also on wednesday, so the availability window ends at the beginning of the
+            # exclusion window
             ConcreteWindow(
                 from_time=arrow.get("2020-06-24 11:01:00").replace(tzinfo="US/Eastern"),
-                to_time=arrow.get("2020-06-24 13:00:00").replace(tzinfo="US/Eastern"),
+                to_time=arrow.get("2020-06-24 12:00:00").replace(tzinfo="US/Eastern"),
             ),
         ),
         (
@@ -111,3 +117,46 @@ def test_weekday_window_on_weekend():
     # now check to see if this is active on a Sunday
     now = arrow.get("2021-09-19 13:00:00").replace(tzinfo="US/Pacific")
     assert in_nonexcluded_window(now, {weekdays}) == False
+
+
+@composite
+def daily_windows(draw):
+    selector = draw(
+        sampled_from(
+            [
+                selectors.daily(),
+                selectors.weekdays(),
+                selectors.weekends(),
+                selectors.weekly_on(draw(sampled_from(selectors.Weekday))),
+            ]
+        )
+    )
+    from_time = draw(times())
+    to_time = draw(times())
+    assume(from_time != to_time)
+    return DailyWindow(is_active_on_day=selector, from_time=from_time, to_time=to_time)
+
+
+@given(
+    inclusions=sets(daily_windows(), min_size=0, max_size=5),
+    exclusions=sets(daily_windows(), min_size=0, max_size=5),
+    now=datetimes(),
+)
+def test_hypothesis(inclusions, exclusions, now):
+    anow = arrow.get(now)
+    # first off, smoke test for assertions/contract violations
+    assert in_nonexcluded_window(anow, inclusions, exclusions) in {
+        True,
+        False,
+    }
+    # now if we reschedule, the rescheduled time should be valid
+    if not in_nonexcluded_window(anow, inclusions, exclusions):
+        if inclusions != set():
+            # we have max_days == 10 so that if the generated availability windows
+            # are weekly we'll get a reschedule
+            nw = next_window(anow, inclusions, exclusions, max_days=10)
+            if nw is not None:
+                rescheduled = nw.begin
+                assert in_nonexcluded_window(
+                    arrow.get(rescheduled), inclusions, exclusions
+                )


### PR DESCRIPTION
Oif.  Fixed how "in_window" worked when abstract windows were reified on days they didn't exist by having "ConcreteWindow" and "NullWindow" classes; sounds complicated but it seems to have worked.  Added a test case for the problem that came up today, and a hypothesis test to generate random sets of inclusion/exclusion windows and try to reschedule, which found another latent defect (I had iterated twice over a generator, so exclusion windows weren't working correctly; this seems to be better).

Let's have a go; this should work somewhat better.
